### PR TITLE
Update extra-cmake-modules syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ASTEROID_MODULE_PATH})
 include(FindPkgConfig)
 include(FeatureSummary)
 include(GNUInstallDirs)
-include(ECMQMLModules)
+include(ECMFindQmlModule)
 include(AsteroidCMakeSettings)
 include(AsteroidTranslations)
 


### PR DESCRIPTION
This is the complementary change to
https://github.com/AsteroidOS/meta-asteroid/pull/105

Signed-off-by: Ed Beroset <beroset@ieee.org>