### PR TITLE
[TimePickerDialog] Give Spinners Dims.w(5) margin

### DIFF
--- a/alarmclock/TimePickerDialog.qml
+++ b/alarmclock/TimePickerDialog.qml
@@ -21,6 +21,7 @@ import QtQuick 2.9
 import Nemo.Time 1.0
 import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
 
 Item {
     id: root
@@ -47,9 +48,13 @@ Item {
 
     Row {
         id: timeSelector
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: title.bottom
+        anchors {
+            left: parent.left
+            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+            right: parent.right
+            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+            top: title.bottom
+        }
         height: Dims.h(60)
 
         property int spinnerWidth: use12H.value ? width/3 : width/2


### PR DESCRIPTION
- Add left and rightMargin to narrow spinners into the center
- Only for round watches
- Improve touch UX on watches with rim that give a hard time reaching the outer edges of the screen

![alarmclock](https://user-images.githubusercontent.com/15074193/232631282-f53b87d2-8a3c-42a6-816c-4e1b95813b54.jpg)
