### PR TITLE
Switch invoker to use booster-qt5

### DIFF
--- a/alarmclock/asteroid-alarmclock.in
+++ b/alarmclock/asteroid-alarmclock.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-alarmclock.so
+exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-alarmclock.so

--- a/alarmpresenter/CMakeLists.txt
+++ b/alarmpresenter/CMakeLists.txt
@@ -1,11 +1,18 @@
 add_library(asteroid-alarmpresenter main.cpp resources.qrc)
-set_target_properties(asteroid-alarmpresenter PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-alarmpresenter PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-alarmpresenter PRIVATE
 	AsteroidApp
 	Mapplauncherd_qt5::Mapplauncherd_qt5)
 
 install(TARGETS asteroid-alarmpresenter
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-alarmpresenter.in
+	${CMAKE_BINARY_DIR}/asteroid-alarmpresenter
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-alarmpresenter
 	DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES com.nokia.voland.service

--- a/alarmpresenter/alarmpresenter.service
+++ b/alarmpresenter/alarmpresenter.service
@@ -7,5 +7,5 @@ Type=dbus
 BusName=com.nokia.voland
 Environment=QT_WAYLAND_DISABLE_WINDOWDECORATION=1
 EnvironmentFile=-/var/lib/environment/mapplauncherd/qtcomponents-qt5.conf
-ExecStart=/usr/bin/invoker --type=qtcomponents-qt5 /usr/bin/asteroid-alarmpresenter
+ExecStart=asteroid-alarmpresenter
 ExecStop=

--- a/alarmpresenter/asteroid-alarmpresenter.in
+++ b/alarmpresenter/asteroid-alarmpresenter.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-alarmpresenter.so


### PR DESCRIPTION
booster-qtcomponents-qt5 has been deprecated upstream and the application launches fine with just booster-qt5 as well