### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/alarmclock/CMakeLists.txt
+++ b/alarmclock/CMakeLists.txt
@@ -1,10 +1,17 @@
 add_library(asteroid-alarmclock main.cpp resources.qrc)
-set_target_properties(asteroid-alarmclock PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-alarmclock PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-alarmclock PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-alarmclock
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-alarmclock.in
+	${CMAKE_BINARY_DIR}/asteroid-alarmclock
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-alarmclock
 	DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 build_translations(i18n)

--- a/alarmclock/asteroid-alarmclock.desktop.template
+++ b/alarmclock/asteroid-alarmclock.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-alarmclock
+Exec=asteroid-alarmclock
 Icon=ios-alarm-outline
 X-Asteroid-Center-Color=#CC9800
 X-Asteroid-Outer-Color=#0C0500

--- a/alarmclock/asteroid-alarmclock.in
+++ b/alarmclock/asteroid-alarmclock.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-alarmclock.so


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker