### PR TITLE
Add timer recycle

### DIFF
--- a/alarmpresenter/main.qml
+++ b/alarmpresenter/main.qml
@@ -77,8 +77,9 @@ Application {
         wrapMode: Text.WordWrap
         lineHeight: Dims.l(0.2)
         text: {
-            if(alarmDialog == undefined || alarmDialog == null)
+            if (alarmDialog == undefined || alarmDialog == null) {
                 return ""
+            }
             else if (alarmDialog.type === Alarm.Calendar || alarmDialog.type === Alarm.Countdown) {
                 font.pixelSize = Dims.l(8)
                 return alarmDialog.title
@@ -124,18 +125,24 @@ Application {
 
     IconButton {
         id: alarmSnooze
-        iconName: "ios-sleep-circle-outline"
+        iconName: visible && alarmDialog.type === Alarm.Countdown ? "ios-refresh-circle-outline" : "ios-sleep-circle-outline"
         anchors {
             right: parent.right
             verticalCenter: parent.verticalCenter
             rightMargin: Dims.iconButtonMargin
         }
-        visible: (alarmDialog !== undefined && alarmDialog !== null) && (alarmDialog.type !== Alarm.Countdown)
+        visible: alarmDialog !== undefined && alarmDialog !== null
         onClicked: {
             feedback.stop()
-            if(alarmDialog !== undefined && alarmDialog !== null)
-                alarmDialog.snooze()
-            alarmTimeField.text = ""
+            if(alarmDialog !== undefined && alarmDialog !== null) {
+                if (alarmDialog.type === Alarm.Countdown) {
+                    alarmDialog.enabled = true
+                    alarmDialog.save()
+                } else {
+                    alarmDialog.snooze()
+                    alarmTimeField.text = ""
+                }
+            }
             alarmHandler.dialogOnScreen = false
             window.close()
         }

--- a/alarmpresenter/main.qml
+++ b/alarmpresenter/main.qml
@@ -79,7 +79,7 @@ Application {
         text: {
             if(alarmDialog == undefined || alarmDialog == null)
                 return ""
-            else if (alarmDialog.type === Alarm.Calendar) {
+            else if (alarmDialog.type === Alarm.Calendar || alarmDialog.type === Alarm.Countdown) {
                 font.pixelSize = Dims.l(8)
                 return alarmDialog.title
             }


### PR DESCRIPTION
Based on a comment in Matrix, this now shows a countdown timer's original value (e.g. 4 minutes would be displayed as "00:04:00") instead of "00:00" which was confusing.  Also, this adds a recycle button to, for example, set another 4-minute timer.  The corresponding change has already been made in `asteroid-timer` and merged.