### PR TITLE
Make alarms automatically dismiss after 3 automatic alarm timeouts

### DIFF
--- a/alarmclock/DaysSelectorDialog.qml
+++ b/alarmclock/DaysSelectorDialog.qml
@@ -89,6 +89,7 @@ Item {
 
             alarm.title = "";
             alarm.daysOfWeek = daysString;
+            alarm.maximalTimeoutSnoozeCount = 2; //autosnooze twice, cancel after third ring
             alarm.enabled = true;
 
             alarm.save()

--- a/alarmpresenter/main.qml
+++ b/alarmpresenter/main.qml
@@ -169,7 +169,7 @@ Application {
         onTriggered: {
             feedback.stop()
             if(alarmDialog !== undefined && alarmDialog !== null)
-                alarmDialog.snooze()
+                alarmDialog.close()
             alarmTimeField.text = ""
             alarmHandler.dialogOnScreen = false
             window.close()


### PR DESCRIPTION
This sets the alarms to dismiss after being automatically snoozed twice. 

It would be ideal if this also implemented a notification after the alarm has fired, but for some reason I can't get these notifications to persist, they dismiss immediately. the work for that is currently at https://github.com/dodoradio/asteroid-alarmclock/tree/autosnooze-notification if anyone else wants to take a crack at it. 